### PR TITLE
docs: publish v0.1.5 on the homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,31 @@ Claude Science 的 Windows 启动器、WSL 运行时编排器与 API Bridge 管�
 
 ## 当前版本
 
-CSA 目前提供两条清晰的版本线。普通用户可以选择稳定核心版；需要远程连接和沙盒外 Agent 的用户可以选择功能完整版。
+CSA 目前提供两条清晰的版本线。普通用户可以选择稳定聚合版；需要远程连接和沙盒外 Agent 的用户可以选择功能完整版。
 
 | 版本 | 适合谁 | 主要能力 | 下载 |
 | --- | --- | --- | --- |
-| **v0.1.4 稳定核心版** | 优先考虑启动、API Key 与运行时稳定性 | 基于 v0.1.3-r2，内置已验证的 Claude Science 0.1.25；修复 API Key 切换；增加官方版本检查和安全升级/回退 Prompt | [Release](https://github.com/Dalaoyuan2020/claude-science-assistant/releases/tag/v0.1.4) · [ZIP](https://github.com/Dalaoyuan2020/claude-science-assistant/releases/download/v0.1.4/claude-science-assistant-v0.1.4-release-portable.zip) · [SHA-256](https://github.com/Dalaoyuan2020/claude-science-assistant/releases/download/v0.1.4/claude-science-assistant-v0.1.4-release-portable.zip.sha256) |
-| **v0.2.0 功能完整版** | 需要 Telegram/飞书、Connect 与 Subagent | 在启动器与 Bridge 基础上增加本地消息网关、浏览器连接器、图片回传和外部 Agent 协作 | [Latest Release](https://github.com/Dalaoyuan2020/claude-science-assistant/releases/tag/v0.2.0) |
+| **v0.1.5 稳定聚合版** | 需要可靠启动、API Key 与三模型聚合 | 内置 Claude Science 0.1.25；把决策、视觉、日常分别绑定到订阅与模型；方案一/方案二整套切换；修复切换假成功与长期“正在处理” | [Release](https://github.com/Dalaoyuan2020/claude-science-assistant/releases/tag/v0.1.5) · [ZIP](https://github.com/Dalaoyuan2020/claude-science-assistant/releases/download/v0.1.5/claude-science-assistant-v0.1.5-publish-20260810-release-portable.zip) · [SHA-256](https://github.com/Dalaoyuan2020/claude-science-assistant/releases/download/v0.1.5/claude-science-assistant-v0.1.5-publish-20260810-release-portable.zip.sha256) |
+| **v0.2.0 功能完整版** | 需要 Telegram/飞书、Connect 与 Subagent | 在启动器与 Bridge 基础上增加本地消息网关、浏览器连接器、图片回传和外部 Agent 协作 | [Release](https://github.com/Dalaoyuan2020/claude-science-assistant/releases/tag/v0.2.0) |
 
-### v0.1.4 更新了什么
+### v0.1.5 更新了什么
 
-- **Claude Science 运行时升级**：锁定并校验官方 Linux x64 `0.1.25`，受管实例关闭未验证的后台自动更新。
-- **API Key 切换修复**：切换 Key 时只事务化重启 Bridge，不再停止 Claude Science daemon 或打断当前会话；失败会回滚两侧配置。
-- **版本检查**：读取 Claude Science 官方 `latest` / `stable` 索引，并区分“官方最新”与“CSA 已验证推荐版”。
-- **安全升级与回退**：启动器生成交给本地 Codex 的升级/回退 Prompt，先做哈希校验、SQLite 备份和隔离验证，不静默替换真实运行时。
-- **发布验证**：Rust、Bridge、真实代理链路、便携包结构和 GitHub 回下载 SHA-256 均已通过。
+- **三模型聚合**：决策（Opus）、视觉（Sonnet）和日常（Haiku / Fast）可以分别使用不同订阅与模型，并作为一张路由表同时生效。
+- **两套聚合方案**：方案一和方案二各自保存三条完整映射，预选不会改运行状态，点击“确认切换”后才执行一次事务化切换。
+- **API Key 切换加固**：消除 Bridge 未运行时静默返回成功的路径；切换后核对 `source_path`、配置 revision 与真实上游请求，失败会显示原因并回滚。
+- **模型列表与手动映射**：添加供应商时可以获取真实模型列表；自动建议之后，仍可手动选择决策、视觉和日常模型。
+- **交互收纳**：API 接入区可折叠，API Key 列表最多显示五条，更多订阅在列表内部滚动。
+- **发布验证**：Rust 52 个库测试与 9 个集成测试通过，包内 53 个 Bridge 测试通过，两套方案完成真实切换验收。
+
+#### v0.1.5 三模型对应关系
+
+| Claude Science 模型槽 | CSA 角色 | 推荐用途 |
+| --- | --- | --- |
+| Opus | 决策（default） | 深度思考、复杂科研决策 |
+| Sonnet | 视觉（vision） | 图片、图表与多模态任务 |
+| Haiku / Fast | 日常（fast） | 普通问答与低延迟任务 |
+
+先在 `API 接入` 中保存订阅，再到 `聚合模式` 为三行分别选择订阅和模型。配置完成后点击“保存并应用整套方案”；以后在方案一和方案二之间切换时，先预选，再点击一次“确认切换”。
 
 ## v0.2.0 新功能
 
@@ -37,7 +48,7 @@ v0.2.0 新增两条本地优先链路：Connect 可把本人 Telegram/飞书私�
 
 > 状态说明：可下载稳定版以 GitHub Latest Release 为准；`main` 可能包含下一版本的发布候选，安装或升级请始终下载完整 Release ZIP。
 
-> 验证边界：v0.1.4 已在 Windows 11 10.0.22631 + Ubuntu-24.04 完成运行时升级、Bridge/API Key 切换、真实代理链路和发布包复测；其他差异环境仍建议先运行只读体检。
+> 验证边界：v0.1.5 已在 Windows 11 + Ubuntu-24.04 完成 Bridge/API Key、两套三模型聚合方案、真实代理链路和发布包复测；视觉订阅图片请求与其他差异环境仍建议在目标电脑复验。
 
 [下载最新版](https://github.com/Dalaoyuan2020/claude-science-assistant/releases/latest) · [第一次安装](#快速开始) · [从旧版升级](#从旧版升级) · [实现原理](#实现原理) · [Claude Science 绿皮书](https://github.com/Dalaoyuan2020/claude-science-green-book)
 
@@ -55,7 +66,7 @@ CSA 把这些步骤收口成一个桌面应用：
 - 一个启动器，跑通 Windows 科研链路：体检电脑、安装/修复 WSL 运行时、启动 Claude Science 和本地 Bridge。
 - 告别反复手改配置：API Key 通过模板添加，官方直连、聚合平台、第三方中转和自定义 Base URL 都在同一个入口管理。
 - 先测试，再启用：保存前可测试 API Key 连通性，必要时读取 `/models` 自动生成 Claude 角色到上游模型的映射。
-- 当前只激活一条 Key：已保存 Key 按添加顺序展示，首页聚焦“现在用什么、能不能启动、哪里出问题”。
+- 两种接入模式：API 接入一次激活一条订阅；聚合模式把决策、视觉、日常三条路由作为一个事务同时应用。
 - 默认保护隐私：API Key 使用 Windows 当前用户 DPAPI 加密，界面、日志、诊断包和发布包不应回显明文 Key。
 - 面向新手，也保留工程入口：新手双击 BAT 和启动器即可开始；熟悉命令行的用户仍可使用 PowerShell 脚本和诊断报告。
 - 本地双向 Connect：Telegram 私聊通过 WSL Gateway 和浏览器连接器进入真实 Claude Science 会话，完成回复由 Bridge 旁路回送；当前开发基线也支持把 Claude Science 明确生成的 artifact 图片安全回传 Telegram。MCP/Skill 与工作区文件保留为降级路线，不开放公网端口，也不接受远程 shell。
@@ -190,10 +201,10 @@ Claude Science 侧通常会请求类似 `claude-sonnet-*`、`claude-opus-*`、`c
 
 ### 1. 下载
 
-只从 GitHub Releases 下载官方包。优先稳定核心能力请选择 v0.1.4；需要 Connect 与 Subagent 请选择 v0.2.0：
+只从 GitHub Releases 下载官方包。优先稳定聚合能力请选择 v0.1.5；需要 Connect 与 Subagent 请选择 v0.2.0：
 
-- `claude-science-assistant-v0.1.4-release-portable.zip`
-- `claude-science-assistant-v0.1.4-release-portable.zip.sha256`
+- `claude-science-assistant-v0.1.5-publish-20260810-release-portable.zip`
+- `claude-science-assistant-v0.1.5-publish-20260810-release-portable.zip.sha256`
 
 - `claude-science-assistant-v0.2.0-release-portable.zip`
 - `claude-science-assistant-v0.2.0-release-portable.zip.sha256`
@@ -372,6 +383,9 @@ Ubuntu-24.04 是默认推荐测试路径，便于复现问题；但启动器不�
 | [docs/v0.2-new-features-acceptance.zh-CN.md](docs/v0.2-new-features-acceptance.zh-CN.md) | Connect 与 Subagent 验收矩阵 |
 | [docs/v0.2-technology-and-release-review.zh-CN.md](docs/v0.2-technology-and-release-review.zh-CN.md) | v0.2 技术实现、安全边界与发布审查 |
 | [docs/v0.2-install-upgrade-release-guide.zh-CN.md](docs/v0.2-install-upgrade-release-guide.zh-CN.md) | 新装、并排升级、回退和发布流程 |
+| [docs/github-release-v0.1.5.md](docs/github-release-v0.1.5.md) | v0.1.5 GitHub Release 文案与安装说明 |
+| [docs/v0.1.5-model-switch-and-role-mapping.zh-CN.md](docs/v0.1.5-model-switch-and-role-mapping.zh-CN.md) | 三模型聚合、方案切换与可靠性实现 |
+| [docs/reports/CSA_v015_release_report_20260810.md](docs/reports/CSA_v015_release_report_20260810.md) | v0.1.5 构建、测试、包检与发布证据 |
 | [docs/github-release-v0.1.3.md](docs/github-release-v0.1.3.md) | v0.1.3 GitHub Release 文案 |
 | [docs/v0.1.3-update-record.zh-CN.md](docs/v0.1.3-update-record.zh-CN.md) | v0.1.3 相对 v0.1.2 的完整更新记录 |
 | [docs/retrospectives/2026-07-12-csa-v0.1.3-release-retrospective.zh-CN.md](docs/retrospectives/2026-07-12-csa-v0.1.3-release-retrospective.zh-CN.md) | v0.1.3 当日开发、验收与发布复盘，可作为文章素材 |

--- a/docs/github-release-v0.1.5.md
+++ b/docs/github-release-v0.1.5.md
@@ -1,0 +1,54 @@
+# CSA v0.1.5
+
+CSA v0.1.5 基于 v0.1.4 稳定核心，继续锁定 Claude Science 0.1.25，并完成多订阅三模型聚合与切换可靠性加固。
+
+## 下载
+
+- `claude-science-assistant-v0.1.5-publish-20260810-release-portable.zip`
+- `claude-science-assistant-v0.1.5-publish-20260810-release-portable.zip.sha256`
+
+请只从本仓库 GitHub Release 下载完整 ZIP，并用同页 `.sha256` 文件核验。不要只复制 EXE。
+
+## 新增
+
+- 多订阅角色映射：把决策（default / Opus）、视觉（vision / Sonnet）和快速（fast / Haiku）分别绑定到订阅与模型。
+- 方案一与方案二：每套方案保存完整的三路映射，一次切换整套配置。
+- 预选 + 确认式切换：点击 API Key 或方案只会高亮待生效项，点击“确认切换”后才执行一次事务化切换。
+- 添加供应商时可读取模型列表，并在自动建议后手动修改三层模型。
+- API Key 列表最多显示五条，更多订阅在列表内部滚动；API 接入区可折叠。
+
+## 修复
+
+- 消除 Bridge 未运行时直接返回成功的静默路径。
+- 切换后校验 `source_path`、配置 revision 与真实上游请求；任一步失败都会显示错误并回滚。
+- API Key 预检进程增加 20 秒外层硬超时，避免界面长期停在“正在处理”。
+- 发布包保留可审计的前端产物和 self-test 所需安全检查材料。
+
+## 已知限制
+
+- 裸切 Provider 时，如果模型别名集合发生变化，Claude Science 本体可能需要重启后才会刷新模型列表；使用角色映射可避免这一问题。
+- 当前 `verify-proxy.ps1` 只识别单后端配置，不能正确判断合法的 aggregate-only 三路配置；源码测试、真实方案切换和包内 self-test 已通过，此脚本兼容项保留待修。
+- 在很深的 Windows 解压路径运行 self-test 可能触发传统路径长度限制；建议解压到 `D:\CSA` 等短路径。启动器本身不依赖该测试虚拟环境。
+
+## 首次安装
+
+1. 下载完整 ZIP 和 `.sha256`，核验后解压到新目录。
+2. 推荐解压到短路径，例如 `D:\CSA-v0.1.5`。
+3. 阅读 `docs/quick-start.zh-CN.md`，或把 `docs/prompts/csa-install-or-upgrade-agent-prompt.zh-CN.md` 交给本地 Codex 先做只读体检。
+4. 双击 `claude-science-assistant.exe`，按界面添加供应商并测试连接。
+
+## 从旧版升级
+
+1. 不卸载 WSL、Ubuntu 或 Claude Science 数据。
+2. 把 v0.1.5 完整 ZIP 解压到新目录，不覆盖旧目录。
+3. 关闭旧启动器后运行新目录的 EXE；新版会读取同一 Windows 用户已有的 DPAPI 设置。
+4. 让新版接管 Bridge，确认 `source_path` 指向 v0.1.5 目录，并完成一次真实模型请求。
+5. 保留旧目录作为回退，验收稳定后再删除。
+
+## 校验值
+
+`claude-science-assistant-v0.1.5-publish-20260810-release-portable.zip`
+
+```text
+SHA256 82D8AA53BEAEA4D09E1E3AA41B318AD86675F3976EFA6688CD87CF8CFDF9814A
+```

--- a/docs/reports/CSA_v015_release_report_20260810.md
+++ b/docs/reports/CSA_v015_release_report_20260810.md
@@ -1,0 +1,53 @@
+# CSA v0.1.5 发布报告
+
+人工只需做什么：下载 GitHub Release 的 ZIP 与 `.sha256`，解压到短的新目录，在一台干净或旧版升级电脑上打开启动器；确认版本号为 V0.1.5，分别完成一次视觉订阅图片请求和一次旧版并排升级。其余源码、真实方案切换、包内自检、凭据扫描与 Release 发布均已自动完成或留下明确证据。
+
+## R0-R1：发布前复盘
+
+- 工作副本：`csa-v0.1.5-model-roles`
+- 分支：`codex/csa-v0.1.5-model-roles`
+- 前端：34 modules，构建通过。
+- Rust：52 个库测试 + 9 个集成测试通过，0 failed，3 ignored。
+- Bridge self-test：53 translation tests passed。
+- 真实切换 scheme-2 -> scheme-1：54.8448143 秒，三路聚合、revision 和真实响应均成功。
+- 真实切换 scheme-1 -> scheme-2：48.9163934 秒，三路聚合、revision 和真实响应均成功。
+- 待人工：`verify-proxy.ps1` 只识别单后端 `custom/deepseek/openai_configured`，不识别合法的 `aggregate_upstreams=3` 配置。
+
+## R2-R3：最小加固与回归
+
+- 在 `launcher/src-tauri/src/lib.rs` 新增可通过 stdin 传递敏感输入的 PowerShell 进程超时封装。
+- 只给 `test_api_key_impl` 增加 20 秒外层硬超时；内部 HTTP 45 秒超时、`CSA_BRIDGE_ONLY=1` 和切换预检保持不变。
+- 加固后前端仍为 34 modules；Rust 52 + 9 passed、0 failed、3 ignored；self-test 仍为 53 passed。
+- 未发生回退。
+
+## R4：提交与待人工项
+
+- `037968d feat: add aggregate subscription schemes`
+- `8a4067b fix: bound API key preflight execution`
+- `f5edf38 feat: display the v0.1.5 launcher version`
+- `fcb59f2 docs: record the v0.1.5 release workflow`
+- 待人工：六份互相冲突的 `CSA_T8*20260809.md` 草案保留为本地未跟踪文件，未进入发布提交。
+
+## R5：发布包
+
+- 路径：`dist/release-v0.1.5-publish-20260810/claude-science-assistant-v0.1.5-publish-20260810-release-portable.zip`
+- 大小：90,677,168 字节。
+- SHA-256：`82D8AA53BEAEA4D09E1E3AA41B318AD86675F3976EFA6688CD87CF8CFDF9814A`
+- 内置运行时：Claude Science 0.1.25，运行时 SHA-256 与仓库 manifest 一致。
+
+## R6：包上检测
+
+1. 时间戳：通过。最新打包源码为 `2026-08-10T01:28:22+08:00`，包内 EXE 为 `2026-08-10T01:30:24+08:00`。
+2. 前端 JS：通过。包内 `index-Bakxun1r.js` 对“确认切换”“方案一”“方案二”各命中 1 次。
+3. 包内 self-test：通过。最终 ZIP 解压到短路径后得到 `53 translation tests passed` 和 `self-test passed`。
+4. SHA-256：通过。`.sha256` 声明与独立复算均为 `82D8AA53BEAEA4D09E1E3AA41B318AD86675F3976EFA6688CD87CF8CFDF9814A`。
+
+直接在超长开发路径运行 self-test 会触发 Windows 传统路径长度限制；短路径复测完整通过。
+
+## R7：安全与发布
+
+- 凭据扫描：仓库 120 个文本文件、包内 64 个文本文件；Telegram、OpenAI、Anthropic、GitHub 与 Bearer 凭据模式均为 0 命中。
+- 包内未包含 `.env`、真实 `config.json`、数据库或日志；`setup-token.py` 是公开工具源码，不含凭据。
+- GitHub tag：`v0.1.5`。
+- Release 链接：<https://github.com/Dalaoyuan2020/claude-science-assistant/releases/tag/v0.1.5>
+- 页面更新：README 增加 v0.1.5 下载入口、订阅列表表格、角色/方案绑定表格、安装与升级入口。

--- a/docs/v0.1.5-model-switch-and-role-mapping.zh-CN.md
+++ b/docs/v0.1.5-model-switch-and-role-mapping.zh-CN.md
@@ -1,0 +1,83 @@
+# CSA v0.1.5 模型切换与订阅角色映射
+
+## 修复结论
+
+旧逻辑在配置已经写入后调用 `restart_bridge_after_config`。当状态快照中的 `bridge_running=false` 时，该函数直接返回 `Ok(())`，随后 Windows 设置正常提交，所以界面显示成功；但 Bridge 没有启动，也没有加载新 revision。新配置只有在用户下一次完整启动服务时才会生效。
+
+v0.1.5 删除这条静默早退。无论 Bridge 当前是运行还是停止，配置事务都会执行 Bridge-only `restart` 或 `start`，并通过 `/health` 核对 `_csa_revision`。WSL 发行版缺失、启动失败或 revision 不一致都会返回错误并触发原有回滚。
+
+## 订阅角色数据
+
+启动器设置新增：
+
+```json
+{
+  "activeAggregateSchemeId": "scheme-1",
+  "aggregateSchemes": [
+    {
+      "id": "scheme-1",
+      "name": "方案一",
+      "routes": [
+        {
+          "role": "default | vision | fast",
+          "providerId": "provider-id",
+          "apiKeyId": "key-id",
+          "model": "provider-model-id"
+        }
+      ]
+    },
+    {
+      "id": "scheme-2",
+      "name": "方案二",
+      "routes": []
+    }
+  ]
+}
+```
+
+旧设置没有聚合字段时，原 `roleBindings` 迁移到方案一，方案二保持空白，并且不会自动激活聚合模式。角色映射只引用 DPAPI 加密订阅的本地 ID，不复制或暴露密钥。
+
+`default / vision / fast` 是兼容旧设置和后端接口的稳定 ID。v0.1.5 界面统一显示为：
+
+| 内部 ID | 界面名称 | 用途 |
+| --- | --- | --- |
+| `default` | 决策 | Claude Science 的 Opus 槽位 / 深度思考 |
+| `vision` | 视觉 | Claude Science 的 Sonnet 槽位 / 多模态输入 |
+| `fast` | 日常 | Claude Science 的 Haiku / Fast 槽位 / 快速响应 |
+
+## 使用方式
+
+启动器把模型接入拆成两个互斥页面：
+
+- `API 接入`：直接使用 API Key 列表中的一条订阅及其原始模型映射。
+- `聚合模式`：把决策、视觉、日常三层角色表作为一个整体接入，支持方案一和方案二两套备选表。
+
+具体流程：
+
+1. 在 API 接入页添加供应商并填写 API Key，点击“获取模型列表”。
+2. 启动器根据模型名给出决策、视觉、日常三层建议；建议只是草案，用户可在三行下拉框中手动选择。三层允许使用同一模型。
+3. 进入聚合模式，选择方案一或方案二，为决策、视觉和日常分别选择订阅及模型。
+4. 点击“保存并应用”。启动器一次性写入三条上游路由，执行 Bridge-only 启动/重启并核对 revision；只有整套配置验证成功，界面才显示方案已生效。
+5. Claude Science 的 Opus、Sonnet、Haiku/Fast 三个槽位分别路由到表中的决策、视觉、日常上游，不需要在启动器里逐个点击角色。
+6. 点击另一套已配置完整的方案会整表切换；未配置完整的方案只进入编辑态，不会破坏当前生效方案。
+7. 返回 API 接入页时，启动器重新执行原 API Key 激活流程并清空聚合路由表。
+
+API 接入页支持折叠并记住状态；供应商列表最多显示五条，更多条目在列表内部滚动，“添加供应商”入口保持可见。聚合角色是独立页面，不受 API 页折叠状态影响。
+
+聚合模式仍只有一个本地 Bridge。`model_aliases` 记录 Claude 槽位到 `route_id` 的映射，`aggregate_upstreams` 保存三条独立上游；聚合模式下 `force_model` 必须为空，避免把三个槽位强制压成同一模型。API Key 明文只在 DPAPI 解密和写入 WSL `0600` 配置时短暂出现，不返回前端或日志。
+
+删除正在被当前聚合方案使用的订阅会被拒绝；删除未激活方案引用的订阅时，会同步移除对应路由并要求重新配置。
+
+## 验证记录
+
+- 故障复现：Bridge 停止、Claude Science 运行时，旧逻辑切到 `glm-5.2` 返回成功，但 Bridge 未启动且真实请求超时。
+- 修复复验：同一故障态切到 `gpt-5.6-terra` 后，Bridge 自动启动、revision 更新，真实请求成功。
+- 连续切换：`gpt-5.6-sol`、`claude-opus-4-8`、`gpt-5.6-terra` 均确认实际路由模型；其中旧 `claude-opus-4-8` 订阅上游返回 502，其余两条成功。
+- 聚合路由单测：两个独立 `custom` 上游和一个 Anthropic 上游同时存在时，Opus、Sonnet、Haiku 分别命中自己的密钥、Base URL 与模型；缺失 `route_id` 时关闭式失败，不回退到其他 Key。
+- 自动测试：Rust 单元与回归测试、前端 TypeScript/Vite 构建、`self-test.ps1`、`verify-proxy.ps1`。
+
+## 待人工复验
+
+- 把视觉角色绑定到真实支持图片输入的订阅，发送一张图片并确认实际路由与回答。
+- 在正式便携包中从 v0.1.4 并排升级，确认旧项目、九条本地订阅和 DPAPI 解密正常。
+- 在无历史设置的 Windows 用户环境完成首次安装与三角色保存。


### PR DESCRIPTION
## 更新内容
- 将主页稳定核心版本从 v0.1.4 更新为 v0.1.5 稳定聚合版
- 保留 v0.2.0 Connect/Subagent 功能完整版入口
- 增加三模型对应表、预选确认式切换说明和准确下载链接
- 同步 v0.1.5 Release 说明、技术文档与发布验收报告

## 验证
- README 不再残留 v0.1.4 下载入口
- v0.1.5 ZIP/SHA 资产已通过 GitHub Release API 反查
- Markdown diff check 通过
- 变更文件凭据模式扫描 0 命中

本 PR 只更新文档，不合并 v0.1.5 代码到 v0.2.0 main。